### PR TITLE
[NEW][SERVER] Add notification/time update retrieval APIs.

### DIFF
--- a/src/server/ruuxee/__init__.py
+++ b/src/server/ruuxee/__init__.py
@@ -47,6 +47,14 @@ class Application(flask.Flask):
             # Pick default template folder
             flask.Flask.__init__(self, self.__app_name)
         self.config.from_object(config)
+
+        # Check how many items we should check in single query for each
+        # notification and/or timeline. See Core APIs for more details.
+        if "RUUXEE_SINGLE_QUERY_ITEMS" in self.config:
+            self.__items = int(self.config["RUUXEE_SINGLE_QUERY_ITEMS"])
+        else:
+            self.__items = 50
+
     def app_name(self):
         return self.__app_name
 
@@ -57,6 +65,14 @@ class Application(flask.Flask):
     @staticmethod
     def current_session_manager():
         return flask.current_app.config["RUUXEE_SESSION_MANAGER"]
+
+    @property
+    def single_query_items(self):
+        return self.__items
+
+    @staticmethod
+    def current_single_query_items():
+        return flask.current_app.single_query_items
 
 class View(flask.Blueprint):
     """

--- a/src/server/ruuxee/apis/v1/web.py
+++ b/src/server/ruuxee/apis/v1/web.py
@@ -288,9 +288,9 @@ def get_notification_range(begin, end):
     resp = core.get_notification_range(this_person_id, begin, end)
     return make_json_response(resp)
 
-@page.route('/timeline/updates/<since_timestamp>', methods=['GET'])
+@page.route('/timeline/update/<since_timestamp>', methods=['GET'])
 @signin_required
-def get_timeline_updates(since_timestamp):
+def get_timeline_update(since_timestamp):
     """def get_timeline_updates(since_timestamp): -> Json
 
     Get a range of latest updates of timeline later than given
@@ -299,12 +299,12 @@ def get_timeline_updates(since_timestamp):
     core = ruuxee.Application.current_core()
     session = ruuxee.Application.current_session_manager()
     this_person_id = session.authenticated_person_visible_id()
-    resp = core.get_timeline_updates(since_timestamp)
+    resp = core.get_timeline_update(this_person_id, since_timestamp)
     return make_json_response(resp)
 
-@page.route('/notification/updates', methods=['GET'])
+@page.route('/notification/update/<since_timestamp>', methods=['GET'])
 @signin_required
-def get_notification_updates(since_timestamp):
+def get_notification_update(since_timestamp):
     """def get_notification_updates(since_timestamp): -> Json
 
     Get a range of latest updates of notifications later than given
@@ -313,6 +313,6 @@ def get_notification_updates(since_timestamp):
     core = ruuxee.Application.current_core()
     session = ruuxee.Application.current_session_manager()
     this_person_id = session.authenticated_person_visible_id()
-    resp = core.get_notification_updates(since_timestamp)
+    resp = core.get_notification_update(this_person_id, since_timestamp)
     return make_json_response(resp)
 

--- a/src/server/ruuxee/models/v1/mock.py
+++ b/src/server/ruuxee/models/v1/mock.py
@@ -279,6 +279,9 @@ class Cache(object):
     def get_list_range(self, list_name, begin, end):
         return self.__lists[list_name][begin:end]
 
+    def get_list_length(self, list_name):
+        return len(self.__lists[list_name])
+
 class AlwaysBourneZhuWebSession(object):
     """A fake WebSession that deal with login session.
 

--- a/src/server/ruuxee/models/v1/schema.sql
+++ b/src/server/ruuxee/models/v1/schema.sql
@@ -331,6 +331,58 @@ CREATE TABLE ruuxee_topic_v1 (
 --            }
 --       ]
 --
+-- 13. GET http://www.ruuxee.com/api/web/v1/timeline/update/<since_time>
+--   Purpose
+--       Get timeline range started from given timestamp (specified by
+--       since_time.
+--
+--       NOTE: since_time is Epoch second since 1970-01-01 00:00:00.
+--   Status
+--       status_code: HTTP code. All below will miss if code is not 200.
+--       data: A list of items below...
+--       [
+--          {
+--            timestamp: When this action Happens.
+--            action: ID of action
+--            action_display: Display name of action.
+--            "from"
+--            {
+--                same fields of get_person_brief
+--            }
+--            "to"
+--            {
+--                same fields of get_topic_brief, get_person_brief or
+--                get_post_brief
+--            }
+--       ]
+--
+-- 14. GET http://www.ruuxee.com/api/web/v1/notification/update/<since_time>
+--   Purpose
+--       Get notification range started later than given time. notification
+--       is the action performed by other person but target current
+--       logged on user.
+--
+--       NOTE: since_time is Epoch second since 1970-01-01 00:00:00.
+--
+--   Status
+--       status_code: HTTP code. All below will miss if code is not 200.
+--       data: A list of items below...
+--       [
+--          {
+--            timestamp: When this action Happens.
+--            action: ID of action
+--            action_display: Display name of action.
+--            "from"
+--            {
+--                same fields of get_person_brief
+--            }
+--            "to"
+--            {
+--                same fields of get_topic_brief, get_person_brief or
+--                get_post_brief
+--            }
+--       ]
+
 --
 -- NOTE
 -- a. All add* operations must use PUT to retrieve visible_ids.


### PR DESCRIPTION
These two APIs are used to periodically call for updates from frontend
to get the latest updates since specified timeline.

With the two APIs web page can get updates periodically by using
/timeline/update/<since_time> or /notification/update/<since_time>.